### PR TITLE
Update for compatibility with Elasticsearch 6.x.x

### DIFF
--- a/es-index-template.sh
+++ b/es-index-template.sh
@@ -1,135 +1,86 @@
-curl -XPUT "${ES_HOST:-localhost}:${ES_PORT:-9200}/_template/statsd-template" -d '
+curl -XPUT -H 'Content-Type: application/json' "${ES_HOST:-localhost}:${ES_PORT:-9200}/_template/statsd-template" -d '
 {
     "template" : "statsd-*",
     "settings" : {
         "number_of_shards" : 1
     },
     "mappings" : {
-        "counter" : {
+        "stats" : {
             "_source" : { "enabled" : true },
             "properties": {
+                "type": {
+                    "type": "keyword"
+                },
                 "@timestamp": {
                     "type": "date"
                 },
                 "val": {
                     "type": "double",
-                    "index": "not_analyzed"
+                    "index": "true"
                 },
                 "name": {
-                    "type": "string",
-                    "index": "not_analyzed"
-                }
-            }
-        },
-        "gauge" : {
-            "_source" : { "enabled" : true },
-            "properties": {
-                "@timestamp": {
-                    "type": "date"
-                },
-                "val": {
-                    "type": "double",
-                    "index": "not_analyzed"
-                },
-                "name": {
-                    "type": "string",
-                    "index": "not_analyzed"
-                }
-            }
-        },
-        "timer" : {
-            "_source" : { "enabled" : true },
-            "properties": {
-                "@timestamp": {
-                    "type": "date"
-                },
-                "val": {
-                    "type": "double",
-                    "index": "not_analyzed"
-                },
-                "name": {
-                    "type": "string",
-                    "index": "not_analyzed"
-                }
-            }
-        },
-        "timer_data" : {
-            "_source" : { "enabled" : true },
-            "properties": {
-                "@timestamp": {
-                    "type": "date"
+                    "type": "keyword",
+                    "index": "true"
                 },
                 "count_ps": {
                     "type": "float",
-                    "index": "not_analyzed"
+                    "index": "true"
                 },
                 "count": {
                     "type": "float",
-                    "index": "not_analyzed"
+                    "index": "true"
                 },
                 "upper": {
                     "type": "float",
-                    "index": "not_analyzed"
+                    "index": "true"
                 },
                 "lower": {
                     "type": "float",
-                    "index": "not_analyzed"
+                    "index": "true"
                 },
                 "mean": {
                     "type": "float",
-                    "index": "not_analyzed"
+                    "index": "true"
                 },
                 "median": {
                     "type": "float",
-                    "index": "not_analyzed"
-                },
-                "mean": {
-                    "type": "float",
-                    "index": "not_analyzed"
-                },
-                "upper": {
-                    "type": "float",
-                    "index": "not_analyzed"
+                    "index": "true"
                 },
                 "std": {
                     "type": "float",
-                    "index": "not_analyzed"
+                    "index": "true"
                 },
                  "sum": {
                     "type": "float",
-                    "index": "not_analyzed"
+                    "index": "true"
                 },
                 "mean_90": {
                     "type": "float",
-                    "index": "not_analyzed"
+                    "index": "true"
                 },
                 "upper_90": {
                     "type": "float",
-                    "index": "not_analyzed"
+                    "index": "true"
                 },
                 "sum_90": {
                     "type": "float",
-                    "index": "not_analyzed"
+                    "index": "true"
                 },
                 "bin_100": {
                     "type": "integer",
-                    "index": "not_analyzed"
+                    "index": "true"
                 },
                 "bin_500": {
                     "type": "integer",
-                    "index": "not_analyzed"
+                    "index": "true"
                 },
                 "bin_1000": {
                     "type": "integer",
-                    "index": "not_analyzed"
+                    "index": "true"
                 },
                 "bin_inf": {
                     "type": "integer",
-                    "index": "not_analyzed"
-                },
-                "name": {
-                    "type": "string",
-                    "index": "not_analyzed"
+                    "index": "true"
                 }
             }
         }

--- a/lib/elasticsearch.js
+++ b/lib/elasticsearch.js
@@ -54,10 +54,7 @@ function transform(stats, index, type) {
         "_type": "stats"
       }
     }));
-    var innerType = {
-      "type": type
-    };
-    payload.push(JSON.stringify(innerType));
+    stats[i].type = type;
     payload.push(JSON.stringify(stats[i]));
   }
 

--- a/lib/elasticsearch.js
+++ b/lib/elasticsearch.js
@@ -35,6 +35,7 @@ var elasticPort;
 var elasticPath;
 var elasticIndex;
 var elasticIndexTimestamp;
+var elasticType;
 var elasticCountType;
 var elasticTimerType;
 var elasticUsername;
@@ -44,17 +45,17 @@ var elasticCertCa;
 
 var elasticStats = {};
 
-function transform(stats, index, type) {
+function transform(stats, index, statsdType, esType) {
   const payload = [];
 
   for (let i = 0; i < stats.length; i++) {
     payload.push(JSON.stringify({
       index: {
         "_index": index,
-        "_type": "stats"
+        "_type": esType
       }
     }));
-    stats[i].type = type;
+    stats[i].type = statsdType;
     payload.push(JSON.stringify(stats[i]));
   }
 
@@ -89,10 +90,10 @@ function insert(listCounters, listTimers, listTimerData, listGaugeData) {
     statsdIndex += '.' +  indexDt;
   }
 
-  let payload = transform(listCounters, statsdIndex, elasticCountType);
-  payload = payload.concat(transform(listTimers, statsdIndex, elasticTimerType));
-  payload = payload.concat(transform(listTimerData, statsdIndex, elasticTimerType));
-  payload = payload.concat(transform(listGaugeData, statsdIndex, elasticGaugeDataType));
+  let payload = transform(listCounters, statsdIndex, elasticCountType, elasticType);
+  payload = payload.concat(transform(listTimers, statsdIndex, elasticTimerType, elasticType));
+  payload = payload.concat(transform(listTimerData, statsdIndex, elasticTimerType, elasticType));
+  payload = payload.concat(transform(listGaugeData, statsdIndex, elasticGaugeDataType, elasticType));
 
   if (payload.length === 0) {
     // No work to do
@@ -213,6 +214,7 @@ exports.init = function(startup_time, config, events, logger) {
   elasticPath           = configEs.path           || '/';
   elasticIndex          = configEs.indexPrefix    || 'statsd';
   elasticIndexTimestamp = configEs.indexTimestamp || 'day';
+  elasticType           = configEs.indexType      || 'stats';
   elasticCountType      = configEs.countType      || 'counter';
   elasticTimerType      = configEs.timerType      || 'timer';
   elasticTimerDataType  = configEs.timerDataType  || elasticTimerType + '_stats';

--- a/lib/elasticsearch.js
+++ b/lib/elasticsearch.js
@@ -57,7 +57,7 @@ function transform(stats, index, type) {
     var innerType = {
       "type": type
     };
-    payload.push(JSON.stringify(innerType);
+    payload.push(JSON.stringify(innerType));
     payload.push(JSON.stringify(stats[i]));
   }
 

--- a/lib/elasticsearch.js
+++ b/lib/elasticsearch.js
@@ -51,7 +51,7 @@ function transform(stats, index, type) {
     payload.push(JSON.stringify({
       index: {
         "_index": index,
-        "_type": stats
+        "_type": "stats"
       }
     }));
     var innerType = {

--- a/lib/elasticsearch.js
+++ b/lib/elasticsearch.js
@@ -51,9 +51,13 @@ function transform(stats, index, type) {
     payload.push(JSON.stringify({
       index: {
         "_index": index,
-        "_type": type
+        "_type": stats
       }
     }));
+    var innerType = {
+      "type": type
+    };
+    payload.push(JSON.stringify(innerType);
     payload.push(JSON.stringify(stats[i]));
   }
 


### PR DESCRIPTION
ES v6 doesn't support multiple `_type` values in an index, so I took the original 4 types (counter, gauge, timer, timer_data) and collapsed the fields into 1 type (stats). Then I added the `type` field to map to the original `_type` fields. 